### PR TITLE
PointTo Fix

### DIFF
--- a/Source/GLScene.pas
+++ b/Source/GLScene.pas
@@ -3167,13 +3167,13 @@ begin
   // convert absolute to local and adjust object
   if Parent <> nil then
   begin
+    FUp.AsVector := Parent.AbsoluteToLocal(absUp);  
     FDirection.AsVector := Parent.AbsoluteToLocal(absDir);
-    FUp.AsVector := Parent.AbsoluteToLocal(absUp);
   end
   else
   begin
+    FUp.AsVector := absUp;  
     FDirection.AsVector := absDir;
-    FUp.AsVector := absUp;
   end;
   TransformationChanged
 end;


### PR DESCRIPTION
Just changed the update order of Direction and Up vectors and the issue #1 was solved.

The problem occurred when the Up vector has the same orientation than the Direction.

[VectorCrossProduct from Dir(0, -1, 0) and Up(0, 1, 0) is (0, 0, 0)](https://www.wolframalpha.com/input/?i=%280%2C-1%2C0%29cross%280%2C1%2C0%29).

[VectorCrossProduct from Dir(0, 1, 0) and Up(0, 1, 0) is (0, 0, 0)](https://www.wolframalpha.com/input/?i=%280%2C1%2C0%29cross%280%2C1%2C0%29).

When (0,0,0) is set as the Up vector, the problem occurred.
