### PR TITLE
Fix Build2DMipmap causes exception on recent compilers like Delphi 10.4, 10.3

### DIFF
--- a/Source/GLS.ImageUtils.pas
+++ b/Source/GLS.ImageUtils.pas
@@ -4893,8 +4893,15 @@ begin
       Div2(ADstWidth);
       Div2(ADstHeight);
 
-      xscale := MaxFloat((ADstWidth - 1) / (ASrcWidth - 1), 0.25);
-      yscale := MaxFloat((ADstHeight - 1) / (ASrcHeight - 1), 0.25);
+      if ASrcWidth > 1 then
+        xscale := MaxFloat((ADstWidth - 1) / (ASrcWidth - 1), 0.25)
+      else
+        xscale := 0.25;
+
+      if ASrcHeight > 1 then
+        yscale := MaxFloat((ADstHeight - 1) / (ASrcHeight - 1), 0.25)
+      else
+        yscale := 0.25;
 
       // Pre-calculate filter contributions for a row
       ReallocMem(contrib, ADstWidth * SizeOf(TCList));


### PR DESCRIPTION
Hi, thank you for maintaining GLScene.
I really appreciate your work !

By the way, I found a problem around texture handling.
Without this patch, yscale is set to NaN, and that causes overflow exception.
(confirmed on Delphi 10.4 patch 3 &10.3.3)

Please check the attached sample.
[GLSTextureTest.zip](https://github.com/GLScene/GLScene/files/5127928/GLSTextureTest.zip)
