### PR TITLE
Fixed a buffer overrun issue

### DIFF
--- a/Source/GLS.Scene.pas
+++ b/Source/GLS.Scene.pas
@@ -6299,6 +6299,8 @@ begin
           CreateContext(AWindowHandle);
       except
         FreeAndNil(FRenderingContext);
+        if Assigned(FCamera) and Assigned(FCamera.FScene) then
+          FCamera.FScene.RemoveBuffer(Self);
         raise;
       end;
     end;


### PR DESCRIPTION
If `CreateMemoryContext` (GLS.Scene.pas l. 6335) raises an exception, the `FRenderingContext` (GLS.Scene.pas l. 6340) is released.
But it is possible that the `FRenderingContext` instance was assigned to the `FBaseContext` in `AddBuffer` (GLS.Scene.pas l. 5711). If that is the case, the call of `aBuffer.RenderingContext.ShareLists(FBaseContext);` (GLS.Scene.pas l. 5713) then `TGLWindowsContext.DoShareLists` (GLS.WindowsContext l. 1133) will cause a buffer overrun when calling `aContext is TGLWindowsContext` (GLS.WindowsContext l. 1135).