### PR TITLE
Remove CurrentJob after notification

### DIFF
--- a/Source/GLS.CameraController.pas
+++ b/Source/GLS.CameraController.pas
@@ -351,10 +351,10 @@ begin
     end;
     if not CurrentJob.FRunning then
     begin
-      FCameraJobList.Remove(CurrentJob);
       // Notify job
       if Assigned(FOnJobFinished) then
         FOnJobFinished(CurrentJob);
+      FCameraJobList.Remove(CurrentJob);
     end;
   end;
   // AdjustScene;


### PR DESCRIPTION
`FCameraJobList` is a `TGLCameraJobList` inherited of `TObjectList` which has the capability of automatically freeing object entries when they are removed from the list. That means that when `CurrentJob` is removed from the list, it is destroyed.

The list remove must be done after notification in order to avoid a buffer overrun issue if `CurrentJob` is used in `FOnJobFinished(CurrentJob)`